### PR TITLE
Remove `Request` trait

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -87,7 +87,7 @@ impl Display for RequestParams {
 ///
 /// ```
 /// use serde::{Deserialize, Serialize};
-/// use jsonlrpc::{JsonRpcVersion, Request, RequestId};
+/// use jsonlrpc::{JsonRpcVersion, RequestId};
 ///
 /// #[derive(Serialize, Deserialize)]
 /// #[serde(tag = "method", rename_all = "snake_case")]
@@ -95,14 +95,6 @@ impl Display for RequestParams {
 ///     Put { jsonrpc: JsonRpcVersion, id: RequestId, key: String, value: String },
 ///     Get { jsonrpc: JsonRpcVersion, id: RequestId, key: String },
 ///     Delete { jsonrpc: JsonRpcVersion, key: String },
-/// }
-///
-/// impl Request for KvsRequest {
-///     type Response = serde_json::Value;
-///
-///     fn is_notification(&self) -> bool {
-///         matches!(self, KvsRequest::Delete { .. })
-///     }
 /// }
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request includes several changes to the `src` directory, focusing on simplifying the codebase by removing the `Request` trait and updating related methods. The most important changes include removing the `Request` trait, updating the `RpcClient` methods, and modifying tests to reflect these changes.

### Codebase simplification:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L70-L109): Removed the `Request` trait and its implementation, along with related documentation and examples.
* [`src/rpc.rs`](diffhunk://#diff-5cdcc3261dd77eadb37bcd60c5f85affcc9306454ae7bb8128e6d096ae51a631L19-R43): Updated the `RpcClient` methods to remove dependencies on the `Request` trait. Specifically, the `call` method no longer checks if a request is a notification, and the `batch_call` method is replaced with `cast` for notifications. [[1]](diffhunk://#diff-5cdcc3261dd77eadb37bcd60c5f85affcc9306454ae7bb8128e6d096ae51a631L19-R43) [[2]](diffhunk://#diff-5cdcc3261dd77eadb37bcd60c5f85affcc9306454ae7bb8128e6d096ae51a631L3-R5)

### Test updates:

* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L150-R108): Modified tests to use the updated `RpcClient` methods. Replaced `client.call` with `client.cast` for notifications and updated the batch request handling. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L150-R108) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L183-R142)

### Documentation updates:

* [`src/types.rs`](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L90-R90): Removed references to the `Request` trait in the documentation examples. [[1]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L90-R90) [[2]](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L99-L106)
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L57-L58): Removed `serde` imports from the main library file as they are no longer needed.