### PR TITLE
Allow `JsonlStream` to be used for uni-directional operations

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -13,7 +13,7 @@ pub struct JsonlStream<S> {
     write_buf_offset: usize,
 }
 
-impl<S: Read + Write> JsonlStream<S> {
+impl<S> JsonlStream<S> {
     /// Makes a new [`JsonlStream`] instance.
     pub fn new(inner: S) -> JsonlStream<S> {
         JsonlStream {
@@ -26,6 +26,25 @@ impl<S: Read + Write> JsonlStream<S> {
         }
     }
 
+    /// Returns a reference to the inner stream.
+    pub fn inner(&self) -> &S {
+        &self.inner
+    }
+
+    /// Returns a mutable reference to the inner stream.
+    pub fn inner_mut(&mut self) -> &mut S {
+        &mut self.inner
+    }
+
+    /// Consumes the [`JsonlStream`] and returns the inner stream.
+    ///
+    /// Note that any remaining data in the read and write buffers will be lost.
+    pub fn into_inner(self) -> S {
+        self.inner
+    }
+}
+
+impl<S: Read> JsonlStream<S> {
     /// Reads a JSONL object from the stream.
     ///
     /// Note that if the inner stream is in non-blocking mode, this method may return
@@ -80,6 +99,13 @@ impl<S: Read + Write> JsonlStream<S> {
         }
     }
 
+    /// Returns the incomplete JSON line in the read buffer.
+    pub fn read_buf(&self) -> &[u8] {
+        &self.read_buf[self.read_buf_offset..self.read_buf_end]
+    }
+}
+
+impl<S: Write> JsonlStream<S> {
     /// Writes a JSONL object to the stream.
     ///
     /// Note that if the inner stream is in non-blocking mode, this method may return
@@ -120,30 +146,8 @@ impl<S: Read + Write> JsonlStream<S> {
         Ok(())
     }
 
-    /// Returns the incomplete JSON line in the read buffer.
-    pub fn read_buf(&self) -> &[u8] {
-        &self.read_buf[self.read_buf_offset..self.read_buf_end]
-    }
-
     /// Returns the remaining data in the write buffer.
     pub fn write_buf(&self) -> &[u8] {
         &self.write_buf[self.write_buf_offset..]
-    }
-
-    /// Returns a reference to the inner stream.
-    pub fn inner(&self) -> &S {
-        &self.inner
-    }
-
-    /// Returns a mutable reference to the inner stream.
-    pub fn inner_mut(&mut self) -> &mut S {
-        &mut self.inner
-    }
-
-    /// Consumes the [`JsonlStream`] and returns the inner stream.
-    ///
-    /// Note that any remaining data in the read and write buffers will be lost.
-    pub fn into_inner(self) -> S {
-        self.inner
     }
 }


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes several changes to the `JsonlStream` struct in the `src/io.rs` file, primarily focusing on refactoring the implementation to separate concerns for reading and writing. Additionally, it introduces new methods for accessing and consuming the inner stream.

Refactoring and method additions:

* Removed the `Read + Write` trait bounds from the main `impl` block of `JsonlStream`, splitting it into separate `impl` blocks for `Read`, `Write`, and `Read + Write` to better isolate functionality. (`src/io.rs`, [src/io.rsL16-R16](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569L16-R16))
* Added methods to access the inner stream:
  * [`inner`](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R29-R47): Returns a reference to the inner stream. (`src/io.rs`, [src/io.rsR29-R47](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R29-R47))
  * [`inner_mut`](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R29-R47): Returns a mutable reference to the inner stream. (`src/io.rs`, [src/io.rsR29-R47](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R29-R47))
  * [`into_inner`](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R29-R47): Consumes the `JsonlStream` and returns the inner stream, noting that any remaining data in the buffers will be lost. (`src/io.rs`, [src/io.rsR29-R47](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R29-R47))
* Moved the `read_buf` method to a separate `impl` block for `Read` to ensure it is only available when the inner stream supports reading. (`src/io.rs`, [src/io.rsR102-R108](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569R102-R108))
* Removed redundant methods from the `Read + Write` `impl` block, as they are now covered by the newly added methods in the respective `Read` and `Write` blocks. (`src/io.rs`, [src/io.rsL123-L148](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569L123-L148))