### PR TITLE
Rename `JsonlStream::{read,write}_object()` with  `JsonlStream::{read,write}_value()` 

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,13 @@ fn spawn_server_thread() -> SocketAddr {
             let stream = stream.expect("failed to accept incoming connection");
             let mut stream = JsonlStream::new(stream);
             std::thread::spawn(move || {
-                let request: RequestObject = stream.read_object().expect("failed to read request");
+                let request: RequestObject = stream.read_value().expect("failed to read request");
                 let response = ResponseObject::Ok {
                     jsonrpc: JsonRpcVersion::V2,
                     id: request.id.expect("expected request id"),
                     result: serde_json::Value::String(request.method),
                 };
-                stream.write_object(&response).expect("failed to write response");
+                stream.write_value(&response).expect("failed to write response");
             });
         }
     });

--- a/src/io.rs
+++ b/src/io.rs
@@ -45,12 +45,12 @@ impl<S> JsonlStream<S> {
 }
 
 impl<S: Read> JsonlStream<S> {
-    /// Reads a JSONL object from the stream.
+    /// Reads a JSONL value from the stream.
     ///
     /// Note that if the inner stream is in non-blocking mode, this method may return
     /// [`ErrorKind::WouldBlock`] error.
     /// If it happens, you should retry this method after the stream becomes readable.
-    pub fn read_object<T>(&mut self) -> Result<T, serde_json::Error>
+    pub fn read_value<T>(&mut self) -> Result<T, serde_json::Error>
     where
         T: for<'a> Deserialize<'a>,
     {
@@ -106,16 +106,16 @@ impl<S: Read> JsonlStream<S> {
 }
 
 impl<S: Write> JsonlStream<S> {
-    /// Writes a JSONL object to the stream.
+    /// Writes a JSONL value to the stream.
     ///
     /// Note that if the inner stream is in non-blocking mode, this method may return
     /// [`ErrorKind::WouldBlock`] error.
     /// If it happens, you should retry by calling [`JsonlStream::flush()`] after the stream becomes writable.
-    pub fn write_object<T>(&mut self, object: &T) -> Result<(), serde_json::Error>
+    pub fn write_value<T>(&mut self, value: &T) -> Result<(), serde_json::Error>
     where
         T: Serialize,
     {
-        serde_json::to_writer(&mut self.write_buf, object)?;
+        serde_json::to_writer(&mut self.write_buf, value)?;
         self.write_buf.push(b'\n');
         self.flush()?;
 
@@ -126,7 +126,7 @@ impl<S: Write> JsonlStream<S> {
     ///
     /// You can use [`JsonlStream::write_buf()`] to check if there is any remaining data in the write buffer.
     ///
-    /// As with [`JsonlStream::write_object()`], this method may return [`ErrorKind::WouldBlock`] error
+    /// As with [`JsonlStream::write_value()`], this method may return [`ErrorKind::WouldBlock`] error
     /// if the inner stream is in non-blocking mode.
     pub fn flush(&mut self) -> Result<(), serde_json::Error> {
         while self.write_buf_offset < self.write_buf.len() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,13 +39,13 @@
 //! #             let stream = stream.expect("failed to accept incoming connection");
 //! #             let mut stream = jsonlrpc::JsonlStream::new(stream);
 //! #             std::thread::spawn(move || {
-//! #                 let request: RequestObject = stream.read_object().expect("failed to read request");
+//! #                 let request: RequestObject = stream.read_value().expect("failed to read request");
 //! #                 let response = ResponseObject::Ok {
 //! #                     jsonrpc: JsonRpcVersion::V2,
 //! #                     id: request.id.expect("expected request id"),
 //! #                     result: serde_json::Value::String(request.method),
 //! #                 };
-//! #                 stream.write_object(&response).expect("failed to write response");
+//! #                 stream.write_value(&response).expect("failed to write response");
 //! #             });
 //! #         }
 //! #     });
@@ -176,7 +176,7 @@ mod tests {
                 let mut stream = JsonlStream::new(stream);
                 std::thread::spawn(move || loop {
                     let request: MaybeBatch<RequestObject> =
-                        stream.read_object().expect("failed to read request");
+                        stream.read_value().expect("failed to read request");
                     match request {
                         MaybeBatch::Single(request) => {
                             if let Some(id) = request.id {
@@ -186,7 +186,7 @@ mod tests {
                                     result: serde_json::Value::String(request.method),
                                 };
                                 stream
-                                    .write_object(&response)
+                                    .write_value(&response)
                                     .expect("failed to write response");
                             }
                         }
@@ -203,7 +203,7 @@ mod tests {
                                 }
                             }
                             stream
-                                .write_object(&responses)
+                                .write_value(&responses)
                                 .expect("failed to write response");
                         }
                     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -27,8 +27,8 @@ impl<S: Read + Write> RpcClient<S> {
         REQ: Serialize,
         RES: for<'de> Deserialize<'de>,
     {
-        self.stream.write_object(request)?;
-        let response = self.stream.read_object()?;
+        self.stream.write_value(request)?;
+        let response = self.stream.read_value()?;
         Ok(response)
     }
 
@@ -39,7 +39,7 @@ impl<S: Read + Write> RpcClient<S> {
     where
         T: Serialize,
     {
-        self.stream.write_object(notification)?;
+        self.stream.write_value(notification)?;
         Ok(())
     }
 


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes several changes to the `JsonlStream` and `RpcClient` implementations to standardize the terminology from "object" to "value" when reading and writing JSONL data. The most important changes involve updating method names and associated documentation to reflect this new terminology.

Changes to method names and documentation:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L57-R63): Updated method calls from `read_object` to `read_value` and from `write_object` to `write_value` in the `spawn_server_thread` function.
* [`src/io.rs`](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569L48-R53): Renamed `read_object` to `read_value` and `write_object` to `write_value` in the `JsonlStream` implementation and updated the corresponding documentation. [[1]](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569L48-R53) [[2]](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569L109-R118) [[3]](diffhunk://#diff-76866598ce8fd16261a27ac58a84b2825e6e77fc37c163a6afa60f0f4477e569L129-R129)
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L42-R48): Updated method calls in examples and tests from `read_object` to `read_value` and from `write_object` to `write_value`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L42-R48) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L179-R179) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L189-R189) [[4]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L206-R206)
* [`src/rpc.rs`](diffhunk://#diff-5cdcc3261dd77eadb37bcd60c5f85affcc9306454ae7bb8128e6d096ae51a631L30-R31): Changed method calls in the `RpcClient` implementation from `write_object` to `write_value` and from `read_object` to `read_value`. [[1]](diffhunk://#diff-5cdcc3261dd77eadb37bcd60c5f85affcc9306454ae7bb8128e6d096ae51a631L30-R31) [[2]](diffhunk://#diff-5cdcc3261dd77eadb37bcd60c5f85affcc9306454ae7bb8128e6d096ae51a631L42-R42)