### PR TITLE
Add `JsonlStream::write_value_to_buf()` method

### DIFF
--- a/src/io.rs
+++ b/src/io.rs
@@ -115,10 +115,21 @@ impl<S: Write> JsonlStream<S> {
     where
         T: Serialize,
     {
+        self.write_value_to_buf(value)?;
+        self.flush()?;
+        Ok(())
+    }
+
+    /// Writes a JSONL value to the write buffer.
+    ///
+    /// This method does not perform I/O operations.
+    /// To send the buffer bytes, please call JsonlStream::flush().
+    pub fn write_value_to_buf<T>(&mut self, value: &T) -> Result<(), serde_json::Error>
+    where
+        T: Serialize,
+    {
         serde_json::to_writer(&mut self.write_buf, value)?;
         self.write_buf.push(b'\n');
-        self.flush()?;
-
         Ok(())
     }
 


### PR DESCRIPTION
Copilot Summary
------------------

This pull request includes a refactor to the `JsonlStream` implementation in `src/io.rs` to improve code organization and readability. The most significant change is the extraction of a new method to handle writing JSONL values to the buffer.

Code refactor and improvements:

* Extracted the logic for writing JSONL values to a new method `write_value_to_buf` to separate concerns and improve code readability.
* Updated the existing method to use the new `write_value_to_buf` method, ensuring the buffer is flushed and the result is returned correctly.