### PR TITLE
Adjust `id` field order

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -102,18 +102,18 @@ pub struct RequestObject {
     /// JSON-RPC version.
     pub jsonrpc: JsonRpcVersion,
 
+    /// Request ID.
+    ///
+    /// If `None`, the request is a notification.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<RequestId>,
+
     /// Method name.
     pub method: String,
 
     /// Request parameters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub params: Option<RequestParams>,
-
-    /// Request ID.
-    ///
-    /// If `None`, the request is a notification.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub id: Option<RequestId>,
 }
 
 impl FromStr for RequestObject {
@@ -211,11 +211,11 @@ pub enum ResponseObject {
         /// JSON-RPC version.
         jsonrpc: JsonRpcVersion,
 
-        /// Result value.
-        result: serde_json::Value,
-
         /// Request ID.
         id: RequestId,
+
+        /// Result value.
+        result: serde_json::Value,
     },
 
     /// Error response.
@@ -223,13 +223,13 @@ pub enum ResponseObject {
         /// JSON-RPC version.
         jsonrpc: JsonRpcVersion,
 
-        /// Error information.
-        error: ErrorObject,
-
         /// Request ID.
         ///
         /// If deserialization of the associated request fails, this field will be `None`.
         id: Option<RequestId>,
+
+        /// Error information.
+        error: ErrorObject,
     },
 }
 


### PR DESCRIPTION
Copilot Summary
-----------------

This pull request includes changes to the `src/types.rs` file to improve the organization and readability of the `RequestObject` and `ResponseObject` structs. The most important changes include reordering the fields within these structs for better logical grouping.

Reorganization of struct fields:

* [`src/types.rs`](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0R105-L116): Moved the `id` field in the `RequestObject` struct to be placed before the `method` and `params` fields for better logical grouping.
* [`src/types.rs`](diffhunk://#diff-ed12f5ea605f23bb4d26cc65778e3daff9db3eec40e2abfc82beafca130a99a0L214-R232): Reordered the `result` and `error` fields in the `ResponseObject` enum to be placed after the `id` field for better logical grouping.